### PR TITLE
Better name generator

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
 	"go.uber.org/zap"
@@ -91,7 +90,7 @@ func (f *Docker) SetUp(ctx context.Context) error {
 	}
 
 	if f.name == "" {
-		f.name = namesgenerator.GetRandomName(0)
+		f.name = GetRandomName(0)
 		if f.namePrefix != "" {
 			f.name = f.namePrefix + "_" + f.name
 		}

--- a/fixtures.go
+++ b/fixtures.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/docker/docker/pkg/namesgenerator"
 	"go.uber.org/zap"
 )
 
@@ -39,7 +38,7 @@ type Fixtures struct {
 
 func (f *Fixtures) Add(ctx context.Context, fixtures ...Fixture) error {
 	for _, fix := range fixtures {
-		if err := f.AddByName(ctx, namesgenerator.GetRandomName(0), fix); err != nil {
+		if err := f.AddByName(ctx, GetRandomName(0), fix); err != nil {
 			return err
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cenkalti/backoff/v3 v3.2.2
 	github.com/charlieparkes/go-structs v1.0.0
 	github.com/docker/docker v20.10.17+incompatible
+	github.com/google/uuid v1.3.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/jackc/pgtype v1.12.0
 	github.com/jackc/pgx/v4 v4.17.1

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=

--- a/namesgenerator.go
+++ b/namesgenerator.go
@@ -1,0 +1,12 @@
+package fixtures
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/pkg/namesgenerator"
+	"github.com/google/uuid"
+)
+
+func GetRandomName(retry int) string {
+	return fmt.Sprint(namesgenerator.GetRandomName(0), "_", uuid.NewString()[:8])
+}

--- a/postgres.go
+++ b/postgres.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/charlieparkes/go-structs"
-	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/iancoleman/strcase"
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
@@ -230,7 +229,7 @@ func (f *Postgres) Connect(ctx context.Context, opts ...PostgresConnOpt) (*pgxpo
 		cfg.poolConfig.ConnConfig.Database = cfg.database
 	}
 	if cfg.createCopy {
-		copiedDatabaseName := namesgenerator.GetRandomName(0)
+		copiedDatabaseName := GetRandomName(0)
 		if err := f.CopyDatabase(ctx, cfg.database, copiedDatabaseName); err != nil {
 			return nil, err
 		}

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,7 +80,7 @@ func TestPostgres(t *testing.T) {
 	})
 
 	t.Run("CreateDatabase", func(t *testing.T) {
-		name := namesgenerator.GetRandomName(0)
+		name := GetRandomName(0)
 		require.NoError(t, p1.CreateDatabase(ctx, name))
 		db, err := p1.Connect(ctx, PostgresConnDatabase(name))
 		require.NoError(t, err)
@@ -91,7 +90,7 @@ func TestPostgres(t *testing.T) {
 	})
 
 	t.Run("CopyDatabase", func(t *testing.T) {
-		databaseName := namesgenerator.GetRandomName(0)
+		databaseName := GetRandomName(0)
 		require.NoError(t, p1.CopyDatabase(ctx, "", databaseName))
 
 		db, err := p1.Connect(ctx, PostgresConnDatabase(databaseName))


### PR DESCRIPTION
The pseudo randomness used by the docker name generator is making test debugging difficult. This change tacks the first segment of a random UUIDv4 to the name.